### PR TITLE
Enable programmatic construction of triples.

### DIFF
--- a/Database/HSparql/QueryGenerator.hs
+++ b/Database/HSparql/QueryGenerator.hs
@@ -63,6 +63,7 @@ module Database.HSparql.QueryGenerator
     -- * Types
     , Query
     , Variable
+    , VarOrNode(..)
     , Pattern
     , SelectQuery(..)
     , ConstructQuery(..)
@@ -272,6 +273,12 @@ instance TermLike (T.Text, IRIRef) where
 instance TermLike Bool where
   varOrTerm = Term . BooleanLiteralTerm
 
+instance TermLike VarOrNode where
+  varOrTerm (Var' v)              = Var v
+  varOrTerm (RDFNode n@(UNode _)) = (Term . IRIRefTerm . AbsoluteIRI) n
+  varOrTerm (RDFNode (LNode lv))  = (Term . RDFLiteralTerm) lv
+  -- TODO: non-exhaustive: missing BNode, BNodeGen
+
 -- Operations
 operation :: (TermLike a, TermLike b) => Operation -> a -> b -> Expr
 operation op x y = NumericExpr $ OperationExpr op (expr x) (expr y)
@@ -422,6 +429,12 @@ data GraphTerm = IRIRefTerm IRIRef
 
 data VarOrTerm = Var Variable
                | Term GraphTerm
+
+-- |Enables programmatic construction of triples where it is not known in
+-- advance which parts of the triple will be variables and which will be
+-- 'Node's.
+data VarOrNode = Var' Variable
+               | RDFNode Node
 
 data Operation = Add | Subtract | Multiply | Divide
 


### PR DESCRIPTION
Example usage:

```
callTest :: IO (Maybe [[BindingValue]])
callTest = test "http://localhost:3030/ds/query"
                (False, UNode (T.pack "http://openhc.org/data/event/Slug_Magazine_Salt_Lake_City_Utah"))
                (True , UNode (T.pack "http://xmlns.com/foaf/0.1/name"))
                (True , LNode (PlainLL (T.pack "Slug Magazine") (T.pack "en")))

test :: String -> (Bool, Node) -> (Bool, Node) -> (Bool, Node) -> IO (Maybe [[BindingValue]])
test url (isSVar, sval) (isPVar, pval) (isOVar, oval) = selectQuery url q
  where
    q = do
        svar <- var
        pvar <- var
        ovar <- var
        triple (if isSVar then Var' svar else RDFNode sval)
               (if isPVar then Var' pvar else RDFNode pval)
               (if isOVar then Var' ovar else RDFNode oval)
        return SelectQuery { queryVars = [svar, pvar, ovar] }
```

This works (with sparql endpoint being jena-fuseki-1.0.0).
