### PR TITLE
Add support for blank nodes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{hs,lhs,hsc}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .*~
 cabal-dev
 dist
+dist-newstyle
 vendor
 TAGS
 sources.txt

--- a/Database/HSparql/Connection.hs
+++ b/Database/HSparql/Connection.hs
@@ -28,7 +28,7 @@ type EndPoint = String
 -- |Local representations of incoming XML results.
 data BindingValue = Bound Data.RDF.Node    -- ^RDF Node (UNode, BNode, LNode)
                   | Unbound       -- ^Unbound result value
-  deriving (Show, Eq)
+                  deriving (Show, Eq)
 
 -- |Base 'QName' for results with a SPARQL-result URI specified.
 sparqlResult :: String -> QName
@@ -38,34 +38,34 @@ sparqlResult s = (unqual s) { qURI = Just "http://www.w3.org/2005/sparql-results
 --  table storing the bindings for each variable in each row.
 structureContent :: String -> Maybe [[BindingValue]]
 structureContent s =
-    do e <- doc
-       return $ map (projectResult $ vars e) $ findElements (sparqlResult "result") e
-    where doc :: Maybe Element
-          doc = parseXMLDoc s
+  do e <- doc
+     return $ map (projectResult $ vars e) $ findElements (sparqlResult "result") e
+  where doc :: Maybe Element
+        doc = parseXMLDoc s
 
-          vars :: Element -> [String]
-          vars = mapMaybe (findAttr $ unqual "name") . findElements (sparqlResult "variable")
+        vars :: Element -> [String]
+        vars = mapMaybe (findAttr $ unqual "name") . findElements (sparqlResult "variable")
 
-          projectResult :: [String] -> Element -> [BindingValue]
-          projectResult vs e = map pVar vs
-             where pVar v   = maybe Unbound (value . head . elChildren) $ filterElement (pred v) e
-                   pred v e = isJust $ do a <- findAttr (unqual "name") e
-                                          guard $ a == v
+        projectResult :: [String] -> Element -> [BindingValue]
+        projectResult vs e = map pVar vs
+          where pVar v = maybe Unbound (value . head . elChildren) $ filterElement (pred_ v) e
+                pred_ v e' = isJust $ do a <- findAttr (unqual "name") e'
+                                         guard $ a == v
 
-          value :: Element -> BindingValue
-          value e =
-            case qName (elName e) of
-              "uri"     -> Bound $ Data.RDF.unode $ (T.pack $ strContent e)
-              "literal" -> case findAttr (unqual "datatype") e of
-                             Just dt -> Bound $ Data.RDF.lnode $ Data.RDF.typedL (T.pack $ strContent e) (T.pack dt)
-                             Nothing -> case findAttr langAttr e of
-                                          Just lang -> Bound $ Data.RDF.lnode $ Data.RDF.plainLL (T.pack $ strContent e) (T.pack lang)
-                                          Nothing   -> Bound $ Data.RDF.lnode $ Data.RDF.plainL (T.pack $ strContent e)
-              -- TODO: what about blank nodes?
-              _         -> Unbound
+        value :: Element -> BindingValue
+        value e =
+          case qName (elName e) of
+            "uri"     -> Bound $ Data.RDF.unode $ (T.pack $ strContent e)
+            "literal" -> case findAttr (unqual "datatype") e of
+                           Just dt -> Bound $ Data.RDF.lnode $ Data.RDF.typedL (T.pack $ strContent e) (T.pack dt)
+                           Nothing -> case findAttr langAttr e of
+                                        Just lang_ -> Bound $ Data.RDF.lnode $ Data.RDF.plainLL (T.pack $ strContent e) (T.pack lang_)
+                                        Nothing    -> Bound $ Data.RDF.lnode $ Data.RDF.plainL (T.pack $ strContent e)
+            -- TODO: what about blank nodes?
+            _         -> Unbound
 
-          langAttr :: QName
-          langAttr = blank_name { qName = "lang", qPrefix = Just "xml" }
+        langAttr :: QName
+        langAttr = blank_name { qName = "lang", qPrefix = Just "xml" }
 
 -- |Parses the response from a SPARQL ASK query. Either "true" or "false" is expected
 parseAsk :: String -> Bool
@@ -73,8 +73,7 @@ parseAsk s
   | (s' == "true" || s' == "yes") = True
   | (s' == "false"|| s' == "no")  = False
   | otherwise = error $ "Unexpected Ask response: " ++ s
- where
-  s' = reverse $ dropWhile (=='\n') $ reverse s
+  where s' = reverse $ dropWhile (=='\n') $ reverse s
 
 -- |Parses the response from a SPARQL UPDATE query.  An empty body is expected
 parseUpdate :: String -> Bool
@@ -86,71 +85,68 @@ parseUpdate s
 --  'Variable's in the 'SelectQuery' action.
 selectQuery :: Database.HSparql.Connection.EndPoint -> Query SelectQuery -> IO (Maybe [[BindingValue]])
 selectQuery ep q = do
-    let uri      = ep ++ "?" ++ urlEncodeVars [("query", createSelectQuery q)]
-        h1 = mkHeader HdrAccept "application/sparql-results+xml"
-        h2 = mkHeader HdrUserAgent "hsparql-client"
-        request = Request { rqURI = fromJust $ parseURI uri
-                          , rqHeaders = [h1,h2]
-                          , rqMethod = GET
-                          , rqBody = ""
-                          }
-    response <- simpleHTTP request >>= getResponseBody
-    return $ structureContent response
+  let uri = ep ++ "?" ++ urlEncodeVars [("query", createSelectQuery q)]
+      h1 = mkHeader HdrAccept "application/sparql-results+xml"
+      h2 = mkHeader HdrUserAgent "hsparql-client"
+      request = Request { rqURI = fromJust $ parseURI uri
+                        , rqHeaders = [h1,h2]
+                        , rqMethod = GET
+                        , rqBody = ""
+                        }
+  response <- simpleHTTP request >>= getResponseBody
+  return $ structureContent response
 
 -- |Connect to remote 'EndPoint' and find all possible bindings for the
 --  'Variable's in the 'SelectQuery' action.
 askQuery :: Database.HSparql.Connection.EndPoint -> Query AskQuery -> IO Bool
 askQuery ep q = do
-    let uri = ep ++ "?" ++ urlEncodeVars [("query", createAskQuery q)]
-        hdr1 = Header HdrUserAgent "hsparql-client"
-        hdr2 = Header HdrAccept "text/plain"
-        hdr3 = Header HdrAccept "text/boolean"
-        hdr4 = Header HdrAcceptCharset "utf-8"
-        request  = insertHeaders [hdr1,hdr2,hdr3,hdr4] (getRequest uri)
-    response <- simpleHTTP request >>= getResponseBody
-    return $ parseAsk response
-
+  let uri = ep ++ "?" ++ urlEncodeVars [("query", createAskQuery q)]
+      hdr1 = Header HdrUserAgent "hsparql-client"
+      hdr2 = Header HdrAccept "text/plain"
+      hdr3 = Header HdrAccept "text/boolean"
+      hdr4 = Header HdrAcceptCharset "utf-8"
+      request  = insertHeaders [hdr1,hdr2,hdr3,hdr4] (getRequest uri)
+  response <- simpleHTTP request >>= getResponseBody
+  return $ parseAsk response
 
 -- |Connect to remote 'EndPoint' and find all possible bindings for the
 --  'Variable's in the 'SelectQuery' action.
 updateQuery :: Database.HSparql.Connection.EndPoint -> Query UpdateQuery -> IO Bool
 updateQuery ep q = do
-    let uri = ep
-        body = createUpdateQuery q
-        h1 = mkHeader HdrContentLength $ show (length body)
-        h2 = mkHeader HdrContentType "application/sparql-update"
-        h3 = mkHeader HdrUserAgent "hsparql-client"
-        request = Request { rqURI = fromJust $ parseURI uri
-                          , rqHeaders = [h1,h2,h3]
-                          , rqMethod = POST
-                          , rqBody = body
-                          }
-    response <- simpleHTTP request >>= getResponseBody
+  let uri = ep
+      body = createUpdateQuery q
+      h1 = mkHeader HdrContentLength $ show (length body)
+      h2 = mkHeader HdrContentType "application/sparql-update"
+      h3 = mkHeader HdrUserAgent "hsparql-client"
+      request = Request { rqURI = fromJust $ parseURI uri
+                        , rqHeaders = [h1,h2,h3]
+                        , rqMethod = POST
+                        , rqBody = body
+                        }
+  response <- simpleHTTP request >>= getResponseBody
 --    return $ structureContent response
-    return $ parseUpdate response
-
+  return $ parseUpdate response
 
 -- |Connect to remote 'EndPoint' and construct 'TriplesGraph' from given
 --  'ConstructQuery' action. /Provisional implementation/.
 constructQuery :: (Rdf a) => Database.HSparql.Connection.EndPoint -> Query ConstructQuery -> IO (RDF a)
 constructQuery ep q = do
-    let uri      = ep ++ "?" ++ urlEncodeVars [("query", createConstructQuery q)]
-    rdfGraph <- httpCallForRdf uri
-    case rdfGraph of
-      Left e -> error $ show e
-      Right graph -> return graph
-   
+  let uri = ep ++ "?" ++ urlEncodeVars [("query", createConstructQuery q)]
+  rdfGraph <- httpCallForRdf uri
+  case rdfGraph of
+    Left e -> error $ show e
+    Right graph -> return graph
 
 -- |Connect to remote 'EndPoint' and construct 'TriplesGraph' from given
 --  'ConstructQuery' action. /Provisional implementation/.
 describeQuery :: (Rdf a) => Database.HSparql.Connection.EndPoint -> Query DescribeQuery -> IO (RDF a)
 describeQuery ep q = do
-    let uri      = ep ++ "?" ++ urlEncodeVars [("query", createDescribeQuery q)]
-    rdfGraph <- httpCallForRdf uri
-    case rdfGraph of
-      Left e -> error $ show e
-      Right graph -> return graph
-    
+  let uri = ep ++ "?" ++ urlEncodeVars [("query", createDescribeQuery q)]
+  rdfGraph <- httpCallForRdf uri
+  case rdfGraph of
+    Left e -> error $ show e
+    Right graph -> return graph
+
 -- |Takes a generated uri and makes simple HTTP request,
 -- asking for RDF N3 serialization. Returns either 'ParseFailure' or 'RDF'
 httpCallForRdf :: Rdf a => String -> IO (Either ParseFailure (RDF a))

--- a/Database/HSparql/QueryGenerator.hs
+++ b/Database/HSparql/QueryGenerator.hs
@@ -632,7 +632,7 @@ data DescribeQuery = DescribeQuery
 -- QueryShow instances
 instance QueryShow BlankNodePattern where
   qshow [] = "[]"
-  qshow xs = intercalate "; " $ fmap qshow xs
+  qshow xs = intercalate ", " $ fmap qshow xs
 
 instance QueryShow DynamicPredicateObject where
   qshow (DynamicPredicate p, DynamicObject o) = mconcat ["[", qshow p, " ", qshow o, "]"]

--- a/hsparql.cabal
+++ b/hsparql.cabal
@@ -34,6 +34,7 @@ library
                , text
                , network-uri
   extensions:  RankNTypes FlexibleInstances OverloadedStrings
+  ghc-options: -Wall -Wcompat
 
 test-suite test-hsparql
   type:          exitcode-stdio-1.0
@@ -53,6 +54,7 @@ test-suite test-hsparql
   hs-source-dirs: Database, tests
   other-modules: Database.HSparql.ConnectionTest
   extensions:  OverloadedStrings, FlexibleInstances
+  ghc-options: -Wall -Wcompat
 
 source-repository head
   type:     git

--- a/tests/AllTests.hs
+++ b/tests/AllTests.hs
@@ -4,38 +4,38 @@ module Main where
 
 import Database.HSparql.ConnectionTest
 
-import Control.Concurrent (forkIO,threadDelay)
-import Control.Exception.Base (bracket_)
-import Network.HTTP.Types (status200, status500)
+import Control.Concurrent (forkIO)
+import Network.HTTP.Types (status200)
 import Network.Wai
 import Network.Wai.Handler.Warp (run)
 import Test.Framework
 
+main :: IO ()
 main =
-  do forkIO $ startServer
+  do _ <- forkIO $ startServer
      ropts <- interpretArgsOrExit []
      defaultMainWithOpts tests ropts
      where tests = Database.HSparql.ConnectionTest.testSuite
 
 app :: Application
 app req respond = respond $ response req
-     where
-       response req = case rawQueryString req of
-                        "?query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20SELECT%20%20%3Fx1%20WHERE%20%7B%3Fx0%20dbpedia%3Agenre%20dbprop%3AWeb_browser%20.%20%3Fx0%20foaf%3Aname%20%3Fx1%20.%7D%20"
-                            -> selectResponse
-                        "?query=PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20ASK%20%7B%20%3Fx0%20dbprop%3Agenre%20dbpedia%3AWeb_browser%20.%20%7D"
-                            -> askResponse
-                        "?query=PREFIX%20example%3A%20%3Chttp%3A%2F%2Fwww.example.com%2F%3E%20PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20CONSTRUCT%20%7B%20%3Fx0%20example%3AhasName%20%3Fx1%20.%20%7D%20WHERE%20%7B%3Fx0%20dbprop%3Agenre%20dbpedia%3AWeb_browser%20.%20%3Fx0%20foaf%3Aname%20%3Fx1%20.%7D"
-                            -> constructResponse
-                        "?query=PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20DESCRIBE%20dbpedia%3AEdinburgh%20WHERE%20%7B%7D"
-                            -> describeResponse
-                        otherwise
-                            -> error $ "Unexpected URI: \n\n" ++ show (rawQueryString req)
+   where
+     response req_ = case rawQueryString req_ of
+                      "?query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20SELECT%20%20%3Fx1%20WHERE%20%7B%3Fx0%20dbpedia%3Agenre%20dbprop%3AWeb_browser%20.%20%3Fx0%20foaf%3Aname%20%3Fx1%20.%7D%20"
+                          -> selectResponse
+                      "?query=PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20ASK%20%7B%20%3Fx0%20dbprop%3Agenre%20dbpedia%3AWeb_browser%20.%20%7D"
+                          -> askResponse
+                      "?query=PREFIX%20example%3A%20%3Chttp%3A%2F%2Fwww.example.com%2F%3E%20PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20CONSTRUCT%20%7B%20%3Fx0%20example%3AhasName%20%3Fx1%20.%20%7D%20WHERE%20%7B%3Fx0%20dbprop%3Agenre%20dbpedia%3AWeb_browser%20.%20%3Fx0%20foaf%3Aname%20%3Fx1%20.%7D"
+                          -> constructResponse
+                      "?query=PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20DESCRIBE%20dbpedia%3AEdinburgh%20WHERE%20%7B%7D"
+                          -> describeResponse
+                      raw_req
+                          -> error $ "Unexpected URI: \n\n" ++ show raw_req
 
-       selectResponse = responseFile status200 [("Content-Type", "application/sparql-results+xml")] "tests/fixtures/sparql_select_response.xml" Nothing
-       askResponse = responseFile status200 [("Content-Type", "text/plain")] "tests/fixtures/sparql_ask_response.text" Nothing
-       constructResponse = responseFile status200 [("Content-Type", "text/turtle")] "tests/fixtures/sparql_construct_response.ttl" Nothing
-       describeResponse = responseFile status200 [("Content-Type", "text/turtle")] "tests/fixtures/sparql_describe_response.ttl" Nothing
+     selectResponse = responseFile status200 [("Content-Type", "application/sparql-results+xml")] "tests/fixtures/sparql_select_response.xml" Nothing
+     askResponse = responseFile status200 [("Content-Type", "text/plain")] "tests/fixtures/sparql_ask_response.text" Nothing
+     constructResponse = responseFile status200 [("Content-Type", "text/turtle")] "tests/fixtures/sparql_construct_response.ttl" Nothing
+     describeResponse = responseFile status200 [("Content-Type", "text/turtle")] "tests/fixtures/sparql_describe_response.ttl" Nothing
 
 
 startServer :: IO ()

--- a/tests/Database/HSparql/ConnectionTest.hs
+++ b/tests/Database/HSparql/ConnectionTest.hs
@@ -1,16 +1,16 @@
 module Database.HSparql.ConnectionTest ( testSuite ) where
 
-import Test.Framework (testGroup)
+import Test.Framework (testGroup, Test)
 import Test.Framework.Providers.HUnit
 import Test.HUnit
 
 import qualified Data.Map as Map
-import qualified Data.Text as T
 import qualified Data.RDF as RDF
 
 import Database.HSparql.Connection
 import Database.HSparql.QueryGenerator
 
+testSuite :: [Test.Framework.Test]
 testSuite = [
     testGroup "Database.HSparql.Connection tests" [
         testCase "selectQuery" test_selectQuery
@@ -20,6 +20,7 @@ testSuite = [
     ]
   ]
 
+test_selectQuery :: IO ()
 test_selectQuery =
   let expectedBVars = Just [ [ Bound $ RDF.lnode $ RDF.plainLL "Kazehakase" "en" ]
                            , [ Bound $ RDF.lnode $ RDF.plainLL "Netscape Browser" "en" ]
@@ -38,25 +39,27 @@ test_selectQuery =
               x    <- var
               name <- var
 
-              triple x (dbpprop .:. "genre") (resource .:. "Web_browser")
-              triple x (foaf .:. "name") name
+              _ <- triple x (dbpprop .:. "genre") (resource .:. "Web_browser")
+              _ <- triple x (foaf .:. "name") name
 
               return SelectQuery { queryVars = [name] }
 
+test_askQuery :: IO ()
 test_askQuery = do
-    bool <- askQuery endPoint query
-    assertBool "invalid" bool
+  bool <- askQuery endPoint query
+  assertBool "invalid" bool
 
-    where endPoint = "http://127.0.0.1:3000"
-          query = do
-              resource <- prefix "dbpedia" (iriRef "http://dbpedia.org/resource/")
-              dbprop  <- prefix "dbprop" (iriRef "http://dbpedia.org/property/")
+  where endPoint = "http://127.0.0.1:3000"
+        query = do
+            resource <- prefix "dbpedia" (iriRef "http://dbpedia.org/resource/")
+            dbprop  <- prefix "dbprop" (iriRef "http://dbpedia.org/property/")
 
-              x <- var
-              ask <- askTriple x (dbprop .:. "genre") (resource .:. "Web_browser")
+            x <- var
+            ask <- askTriple x (dbprop .:. "genre") (resource .:. "Web_browser")
 
-              return AskQuery { queryAsk = [ask] }
+            return AskQuery { queryAsk = [ask] }
 
+test_constructQuery :: IO ()
 test_constructQuery =
   let expectedGraph :: RDF.RDF RDF.TList
       expectedGraph = RDF.mkRdf expectedTriples Nothing (RDF.PrefixMappings Map.empty)
@@ -78,11 +81,12 @@ test_constructQuery =
               name <- var
 
               construct <- constructTriple x (example .:. "hasName") name
-              triple x (dbpprop .:. "genre") (resource .:. "Web_browser")
-              triple x (foaf .:. "name") name
+              _ <- triple x (dbpprop .:. "genre") (resource .:. "Web_browser")
+              _ <- triple x (foaf .:. "name") name
 
               return ConstructQuery { queryConstructs = [construct] }
 
+test_describeQuery :: IO ()
 test_describeQuery =
   let expectedNode = RDF.unode "http://dbpedia.org/resource/Edinburgh"
   in do

--- a/tests/Database/HSparql/ConnectionTest.hs
+++ b/tests/Database/HSparql/ConnectionTest.hs
@@ -58,13 +58,13 @@ test_askQuery = do
               return AskQuery { queryAsk = [ask] }
 
 test_constructQuery =
-  let expectedGraph :: RDF.TriplesList
+  let expectedGraph :: RDF.RDF RDF.TList
       expectedGraph = RDF.mkRdf expectedTriples Nothing (RDF.PrefixMappings Map.empty)
       expectedTriples = [ RDF.Triple (RDF.unode "http://dbpedia.org/resource/Kazehakase")
                                      (RDF.unode "http://www.example.com/hasName")
                                      (RDF.lnode $ RDF.plainLL "Kazehakase" "en") ]
   in do
-    graph <- constructQuery endPoint query :: IO RDF.TriplesList
+    graph <- constructQuery endPoint query :: IO (RDF.RDF RDF.TList)
     assertBool "RDF does not include the constructed triple" $ RDF.isIsomorphic expectedGraph graph
 
     where endPoint = "http://127.0.0.1:3000"
@@ -86,7 +86,7 @@ test_constructQuery =
 test_describeQuery =
   let expectedNode = RDF.unode "http://dbpedia.org/resource/Edinburgh"
   in do
-    graph <- describeQuery endPoint query :: IO RDF.TriplesList
+    graph <- describeQuery endPoint query :: IO (RDF.RDF RDF.TList)
     assertBool "RDF does not include the required node" $ RDF.rdfContainsNode graph expectedNode
 
     where endPoint = "http://127.0.0.1:3000"


### PR DESCRIPTION
I turned on the options `-Wall` and `-Wcompat`.

I added support for blank nodes and nested blank nodes patterns:

```haskell
(&) = mkPredicateObject

q = do
  p <- prefix "" (iriRef "http://example.com/")
  s <- var
  o1 <- var
  o2 <- var
  _ <- triple s (p .:. "p1") [(p .:. "p2") & [(p .:. "p3") & o1], (p .:. "p4") & o2]
  return SelectQuery { queryVars = [s, o1] }

q' = createSelectQuery q
-- q' = "PREFIX : <http://example.com/> SELECT  ?x0 ?x1 WHERE {?x0 :p1 [:p2 [:p3 ?x1]], [:p4 ?x2] .} "
```
