### PR TITLE
Add support for subqueries.

### DIFF
--- a/tests/AllTests.hs
+++ b/tests/AllTests.hs
@@ -21,7 +21,7 @@ app :: Application
 app req respond = respond $ response req
    where
      response req_ = case rawQueryString req_ of
-                      "?query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20SELECT%20%20%3Fx1%20WHERE%20%7B%3Fx0%20dbpedia%3Agenre%20dbprop%3AWeb_browser%20.%20%3Fx0%20foaf%3Aname%20%3Fx1%20.%7D"
+                      "?query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20SELECT%20%3Fx1%20WHERE%20%7B%3Fx0%20dbpedia%3Agenre%20dbprop%3AWeb_browser%20.%20%3Fx0%20foaf%3Aname%20%3Fx1%20.%7D"
                           -> selectResponse
                       "?query=PREFIX%20dbprop%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fproperty%2F%3E%20PREFIX%20dbpedia%3A%20%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2F%3E%20ASK%20%7B%20%3Fx0%20dbprop%3Agenre%20dbpedia%3AWeb_browser%20.%20%7D"
                           -> askResponse


### PR DESCRIPTION
```haskell
-- Utils
a & b = mkPredicateObject a b
triple_ a b c = void $ triple a b c
filterExpr_ = void . filterExpr
subQuery_ = void . subQuery

-- Query
q = do
  p1 <- prefix "" (iriRef "http://example1.com/")
  s <- var
  v <- var
  triple_ s (p1 .:. "property1") (p1 .:. "X")
  filterExpr_ $ (v .>. (10::Integer)) .&&. (v .<. (20::Integer))
  subQuery_ $ do
    p2 <- prefix "ex" (iriRef "http://example2.com/")
    v' <- var
    triple_ s (p1 .:. "property2") [(p2 .:. "property3") & v']
    select [avg v' `as` v]
  selectVars [s]

-- SPARQL
q' = createSelectQuery q
-- PREFIX : <http://example1.com/> PREFIX ex: <http://example2.com/> SELECT ?x0 WHERE {?x0 :property1 :X . FILTER ((?x1>(10))&&(?x1<(20))) . { SELECT ((AVG(?x0_0)) AS ?x1) WHERE {?x0 :property2 [ex:property3 ?x0_0] .} }}
```