### PR TITLE
Fix prefixed name (thing constructed via .:.) not being URI escaped

### DIFF
--- a/Database/HSparql/QueryGenerator.hs
+++ b/Database/HSparql/QueryGenerator.hs
@@ -21,8 +21,8 @@ module Database.HSparql.QueryGenerator
   , describeIRI, describeIRI_
   , optional, optional_
   , union, union_
-  , exists, notExists
   , filterExpr, filterExpr_
+  , filterExists, filterExists_, filterNotExists, filterNotExists_
   , bind, bind_
   , subQuery, subQuery_
   , select
@@ -285,17 +285,25 @@ union q1 q2 = do
 union_ :: Query a -> Query b -> Query ()
 union_ a b = void $ union a b
 
-exists :: Query a -> Query Pattern
-exists q = do
+filterExists :: Query a -> Query Pattern
+filterExists q = do
   let p = execQuery0 q pattern
-      exists' = ExistsPattern p
-  return exists'
+      filterExists' = FilterExistsPattern p
+  modify $ \s -> s { pattern = appendPattern filterExists' (pattern s) }
+  return filterExists'
 
-notExists :: Query a -> Query Pattern
-notExists q = do
+filterExists_ :: Query a -> Query ()
+filterExists_ = void . filterExists
+
+filterNotExists :: Query a -> Query Pattern
+filterNotExists q = do
   let p = execQuery0 q pattern
-      notExists' = NotExistsPattern p
-  return notExists'
+      filterNotExists' = FilterNotExistsPattern p
+  modify $ \s -> s { pattern = appendPattern filterNotExists' (pattern s) }
+  return filterNotExists'
+
+filterNotExists_ :: Query a -> Query ()
+filterNotExists_ = void . filterNotExists
 
 -- |Restrict results to only those for which the given expression is true.
 filterExpr :: (TermLike a) => a -> Query Pattern
@@ -330,7 +338,7 @@ subQuery q = do
   -- Merge prefixes
   prefixesParentQuery <- gets prefixes
   let prefixesSubQuery = prefixes subQueryData
-      newPrefixes = prefixesParentQuery `L.union` prefixesSubQuery
+      newPrefixes = prefixesSubQuery `L.union` prefixesParentQuery
   -- Create the subquery pattern and remove prefixes from the subquery
   let sq = SubQuery $ subQueryData { prefixes = [] }
   -- Append the subquery pattern, update the subquery index and the prefixes.
@@ -858,12 +866,12 @@ e `as` v = SelectExpr e v
 
 data Pattern = QTriple VarOrTerm VarOrTerm VarOrTerm
              | Filter Expr
+             | FilterExistsPattern GroupGraphPattern
+             | FilterNotExistsPattern GroupGraphPattern
              | Bind Expr Variable
              | OptionalGraphPattern GroupGraphPattern
              | UnionGraphPattern GroupGraphPattern GroupGraphPattern
              | SubQuery QueryData
-             | ExistsPattern GroupGraphPattern
-             | NotExistsPattern GroupGraphPattern
                deriving (Show)
 
 data GroupGraphPattern = GroupGraphPattern [Pattern]
@@ -1067,14 +1075,14 @@ instance QueryShow [SelectExpr] where
   qshow = intercalate " " . fmap qshow
 
 instance QueryShow Pattern where
-  qshow (QTriple a b c) = intercalate " " [qshow a, qshow b, qshow c, "."]
-  qshow (Filter e)      = "FILTER " ++ qshow e ++ " ."
-  qshow (Bind e v)      = "BIND(" ++ qshow e ++ " AS " ++ qshow v ++ ")"
-  qshow (OptionalGraphPattern p)  = "OPTIONAL " ++ qshow p
-  qshow (UnionGraphPattern p1 p2) = qshow p1 ++ " UNION " ++ qshow p2
-  qshow (ExistsPattern p) = "EXISTS" ++ qshow p
-  qshow (NotExistsPattern p) = "NOT EXISTS" ++ qshow p
-  qshow (SubQuery qd)   = intercalate " " ["{ ", qshow qd, " }"]
+  qshow (QTriple a b c)            = intercalate " " [qshow a, qshow b, qshow c, "."]
+  qshow (Filter e)                 = "FILTER " ++ qshow e ++ " ."
+  qshow (FilterExistsPattern p)    = "FILTER EXISTS " ++ qshow p
+  qshow (FilterNotExistsPattern p) = "FILTER NOT EXISTS " ++ qshow p
+  qshow (Bind e v)                 = "BIND(" ++ qshow e ++ " AS " ++ qshow v ++ ")"
+  qshow (OptionalGraphPattern p)   = "OPTIONAL " ++ qshow p
+  qshow (UnionGraphPattern p1 p2)  = qshow p1 ++ " UNION " ++ qshow p2
+  qshow (SubQuery qd)              = intercalate " " ["{ ", qshow qd, " }"]
 
 instance QueryShow [Pattern] where
   qshow = unwords . fmap qshow

--- a/Database/HSparql/QueryGenerator.hs
+++ b/Database/HSparql/QueryGenerator.hs
@@ -125,6 +125,7 @@ import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.RDF as RDF
+import qualified Network.URI as URI
 
 -- State monads
 
@@ -972,7 +973,8 @@ instance QueryShow [Variable] where
 
 instance QueryShow IRIRef where
   qshow (AbsoluteIRI n) = qshow n
-  qshow (PrefixedName (Prefix pre _) s) = (T.unpack pre) ++ ":" ++ (T.unpack s)
+  qshow (PrefixedName (Prefix pre _) s) = (T.unpack pre) ++ ":" ++ (escape $ T.unpack s)
+    where escape = URI.escapeURIString URI.isUnescapedInURIComponent
 
 instance QueryShow (Maybe IRIRef) where
   qshow (Just r) = qshow r

--- a/Database/HSparql/QueryGenerator.hs
+++ b/Database/HSparql/QueryGenerator.hs
@@ -953,7 +953,7 @@ instance QueryShow Prefix where
   qshow (Prefix pre ref) = "PREFIX " ++ (T.unpack pre) ++ ": " ++ qshow ref
 
 instance QueryShow [Prefix] where
-  qshow = unwords . fmap qshow
+  qshow = unwords . reverse . fmap qshow
 
 instance QueryShow Variable where
   qshow (Variable vs) = "?x" ++ indexes
@@ -1074,13 +1074,13 @@ instance QueryShow Pattern where
   qshow (UnionGraphPattern p1 p2) = qshow p1 ++ " UNION " ++ qshow p2
   qshow (ExistsPattern p) = "EXISTS" ++ qshow p
   qshow (NotExistsPattern p) = "NOT EXISTS" ++ qshow p
-  qshow (SubQuery qd)   = intercalate " " ["{", qshow qd, "}"]
+  qshow (SubQuery qd)   = intercalate " " ["{ ", qshow qd, " }"]
 
 instance QueryShow [Pattern] where
   qshow = unwords . fmap qshow
 
 instance QueryShow GroupGraphPattern where
-  qshow (GroupGraphPattern ps) = "{" ++ qshow ps ++ "}"
+  qshow (GroupGraphPattern ps) = "{ " ++ qshow ps ++ " }"
 
 instance QueryShow GroupBy where
   qshow (GroupBy e) = qshow e

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ Here's the respective type:
 askQuery :: EndPoint -> Query AskQuery -> IO Bool
 ```
 
+### More examples
+
+Some extra examples can be found in [tests](tests/Database/HSparql/QueryGeneratorTest.hs).
 
 ## TODOs
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ CONSTRUCT {
   ?x example:hasName ?name
 }
 WHERE {
-  ?x dbprop:genre resource:Web_browser
+  ?x dbprop:genre dbpedia:Web_browser
   ?x foaf:name ?name
   ?x foaf:page ?page
 }

--- a/hsparql.cabal
+++ b/hsparql.cabal
@@ -50,6 +50,7 @@ test-suite test-hsparql
                  , wai >= 3.0.0
                  , warp >= 3.0.1
                  , network-uri
+                 , string-qq
   hs-source-dirs: Database, tests
   other-modules: Database.HSparql.ConnectionTest
   extensions:  OverloadedStrings, FlexibleInstances

--- a/hsparql.cabal
+++ b/hsparql.cabal
@@ -53,6 +53,7 @@ test-suite test-hsparql
                  , string-qq
   hs-source-dirs: Database, tests
   other-modules: Database.HSparql.ConnectionTest
+               , Database.HSparql.QueryGeneratorTest
   extensions:  OverloadedStrings, FlexibleInstances
   ghc-options: -Wall -Wcompat
 

--- a/tests/Database/HSparql/QueryGeneratorTest.hs
+++ b/tests/Database/HSparql/QueryGeneratorTest.hs
@@ -227,6 +227,26 @@ WHERE
         selectVars [person]
     )
 
+  , ( [s|
+PREFIX ex: <http://example.com/>
+
+SELECT ?x0 ?x1
+WHERE
+{
+  ?x0 ex:foo%20bar ?x1 .
+}
+|]
+    , createQuery $ do
+        ex <- prefix "ex" (iriRef "http://example.com/")
+
+        s <- var
+        o <- var
+
+        triple_ s (ex .:. "foo bar") o
+
+        selectVars [s, o]
+    )
+
   ]
 
 testSuite :: [Test.Framework.Test]

--- a/tests/Database/HSparql/QueryGeneratorTest.hs
+++ b/tests/Database/HSparql/QueryGeneratorTest.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Database.HSparql.QueryGeneratorTest ( testSuite ) where
+
+import Test.Framework (testGroup, Test)
+import Test.Framework.Providers.HUnit
+import Test.HUnit
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.String.QQ (s)
+
+import Database.HSparql.QueryGenerator
+
+class CreateQuery a where
+  createQuery :: a -> Text
+
+instance CreateQuery (Query SelectQuery) where
+  createQuery = T.pack . createSelectQuery
+
+instance CreateQuery (Query ConstructQuery) where
+  createQuery = T.pack . createConstructQuery
+
+instance CreateQuery (Query AskQuery) where
+  createQuery = T.pack . createAskQuery
+
+instance CreateQuery (Query UpdateQuery) where
+  createQuery = T.pack . createUpdateQuery
+
+instance CreateQuery (Query DescribeQuery) where
+  createQuery = T.pack . createDescribeQuery
+
+normalizeWhitespace :: Text -> Text
+normalizeWhitespace = T.strip . (T.replace "   " " ") . (T.replace "\n" " ")
+
+queryTexts :: [(Text, Text)]
+queryTexts =
+  [ ( [s|
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+PREFIX dbprop: <http://dbpedia.org/property/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?x1 ?x2
+WHERE {
+  ?x0 dbprop:genre dbpedia:Web_browser .
+  ?x0 foaf:name ?x1 .
+  ?x0 foaf:page ?x2 .
+}
+|]
+    , createQuery $ do
+        resource <- prefix "dbpedia" (iriRef "http://dbpedia.org/resource/")
+        dbpprop  <- prefix "dbprop" (iriRef "http://dbpedia.org/property/")
+        foaf     <- prefix "foaf" (iriRef "http://xmlns.com/foaf/0.1/")
+
+        x    <- var
+        name <- var
+        page <- var
+
+        triple_ x (dbpprop .:. "genre") (resource .:. "Web_browser")
+        triple_ x (foaf .:. "name") name
+        triple_ x (foaf .:. "page") page
+
+        selectVars [name, page]
+    )
+
+  , ( [s|
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+PREFIX dbprop: <http://dbpedia.org/property/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX example: <http://www.example.com/>
+CONSTRUCT {
+  ?x0 example:hasName ?x1 .
+}
+WHERE {
+  ?x0 dbprop:genre dbpedia:Web_browser .
+  ?x0 foaf:name ?x1 .
+  ?x0 foaf:page ?x2 .
+}
+|]
+    , createQuery $ do
+        resource <- prefix "dbpedia" (iriRef "http://dbpedia.org/resource/")
+        dbpprop  <- prefix "dbprop" (iriRef "http://dbpedia.org/property/")
+        foaf     <- prefix "foaf" (iriRef "http://xmlns.com/foaf/0.1/")
+        example  <- prefix "example" (iriRef "http://www.example.com/")
+
+        x    <- var
+        name <- var
+        page <- var
+
+        construct <- constructTriple x (example .:. "hasName") name
+
+        triple_ x (dbpprop .:. "genre") (resource .:. "Web_browser")
+        triple_ x (foaf .:. "name") name
+        triple_ x (foaf .:. "page") page
+
+        return ConstructQuery { queryConstructs = [construct] }
+    )
+
+  , ( [s|
+PREFIX dbpedia: <http://dbpedia.org/resource/> DESCRIBE dbpedia:Edinburgh WHERE {  }
+|]
+    , createQuery $ do
+        resource <- prefix "dbpedia" (iriRef "http://dbpedia.org/resource/")
+        uri <- describeIRI (resource .:. "Edinburgh")
+        return DescribeQuery { queryDescribe = uri }
+    )
+
+  , ( [s|
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+PREFIX dbprop: <http://dbpedia.org/property/>
+ASK {
+  ?x0 dbprop:genre dbpedia:Web_browser .
+}
+|]
+    , createQuery $ do
+        resource <- prefix "dbpedia" (iriRef "http://dbpedia.org/resource/")
+        dbprop  <- prefix "dbprop" (iriRef "http://dbpedia.org/property/")
+
+        x <- var
+        ask <- askTriple x (dbprop .:. "genre") (resource .:. "Web_browser")
+
+        return AskQuery { queryAsk = [ask] }
+    )
+
+  ]
+
+testSuite :: [Test.Framework.Test]
+testSuite = [
+    testGroup "Database.HSparql.QueryGenerator tests" $ (`map` queryTexts) $
+      \(expected, actual) -> testCase (T.unpack expected) $ do
+        assertEqual "" (normalizeWhitespace expected) (normalizeWhitespace actual)
+  ]


### PR DESCRIPTION
Depends on #38

Added commit atop #38 is https://github.com/robstewart57/hsparql/pull/39/commits/e4293116660cc6aa3c142f00d4b14c9ce4147e4f