### PR TITLE
LTS 23.7 Upgrade

### DIFF
--- a/Database/HSparql/Connection.hs
+++ b/Database/HSparql/Connection.hs
@@ -26,6 +26,7 @@ import Control.Monad
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as LB
+import Data.Default (def)
 import Data.Maybe (isJust, mapMaybe)
 import qualified Data.RDF as RDF
 import qualified Data.Text as T
@@ -143,7 +144,7 @@ selectQueryRaw ep q = do
           { method = "GET",
             requestHeaders = [h1, h2]
           }
-  let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
+  let settings = mkManagerSettings (TLSSettingsSimple True False False def) Nothing
   manager <- liftIO $ newManager settings
   resp <- httpLbs request manager
   return $ structureContent (LB.unpack (responseBody resp))
@@ -161,7 +162,7 @@ askQueryRaw ep q = do
           { method = "GET",
             requestHeaders = [h1, h2, h3, h4]
           }
-  let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
+  let settings = mkManagerSettings (TLSSettingsSimple True False False def) Nothing
   manager <- liftIO $ newManager settings
   resp <- httpLbs request manager
   return $ parseAsk (LB.unpack (responseBody resp))
@@ -180,7 +181,7 @@ updateQueryRaw ep q = do
             requestHeaders = [h1, h2, h3],
             requestBody = RequestBodyBS (T.encodeUtf8 (T.pack body))
           }
-  let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
+  let settings = mkManagerSettings (TLSSettingsSimple True False False def) Nothing
   manager <- liftIO $ newManager settings
   resp <- httpLbs request manager
   return $ parseUpdate (LB.unpack (responseBody resp))
@@ -213,7 +214,7 @@ httpCallForRdf uri = do
           { method = "GET",
             requestHeaders = [h1, h2]
           }
-  let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
+  let settings = mkManagerSettings (TLSSettingsSimple True False False def) Nothing
   manager <- liftIO $ newManager settings
   resp <- httpLbs request manager
   return $ RDF.parseString (TurtleParser Nothing Nothing) $ E.decodeUtf8 (LB.toStrict (responseBody resp))

--- a/Database/HSparql/QueryGenerator.hs
+++ b/Database/HSparql/QueryGenerator.hs
@@ -184,6 +184,7 @@ module Database.HSparql.QueryGenerator
   )
 where
 
+import Control.Monad (void)
 import Control.Monad.State
 import Data.List (intercalate, intersperse)
 import qualified Data.List as L

--- a/hsparql.cabal
+++ b/hsparql.cabal
@@ -23,6 +23,7 @@ library
   Exposed-modules: Database.HSparql.Connection
                  , Database.HSparql.QueryGenerator
   Build-depends: base >= 4 && < 5
+               , data-default
                , HTTP >= 4
                , mtl
                , xml
@@ -35,7 +36,7 @@ library
                , http-client
                , http-types
                , http-conduit
-               , connection
+               , crypton-connection
                , bytestring
   ghc-options: -Wall -Wcompat
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - '.'
 extra-deps:
 - git: https://github.com/robstewart57/rdf4h.git
-  commit: 018755800c6503ddebe27efb7261be1c95ee2f12
+  commit: c6ab9c7990b97a7ea9037da91f6fe9de9bc73805

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.11
+resolver: lts-23.7
 packages:
 - '.'
 extra-deps:

--- a/tests/Database/HSparql/QueryGeneratorTest.hs
+++ b/tests/Database/HSparql/QueryGeneratorTest.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE PostfixOperators  #-}
+{-# LANGUAGE PostfixOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Database.HSparql.QueryGeneratorTest ( testSuite ) where
 


### PR DESCRIPTION
This PR contains the following changes:

- Upgrade Stack resolver from 20.11 to 23.7
- Update git ref for `rdf4h` to current `master`
- Change `connection` dependency to `crypton-connection` as `connection` has been [archived](https://github.com/vincenthz/hs-connection) and `crypton-connection` seems to be the community-recommended replacement.
- Made the necessary code changes needed for the above updates.

This change was prompted by my attempting to use `hsparql` as a dependency in a project that I'm building with Nix and these changes are needed to make that work.